### PR TITLE
Add dependencies for block

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ None
 
 Dependencies
 ------------
-
 -   [requests](https://pypi.python.org/pypi/requests/)
 -   [requests_oauthlib](https://pypi.python.org/pypi/requests-oauthlib)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ None
 
 Dependencies
 ------------
-None
+
+-   [requests](https://pypi.python.org/pypi/requests/)
+-   [requests_oauthlib](https://pypi.python.org/pypi/requests-oauthlib)
 
 Commands
 --------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+requests_oauthlib


### PR DESCRIPTION
These didn't exist and were causing block installs to fail. Is there anywhere I need to add them besides the `requirements.txt` file @hansmosh @cowleyk ?